### PR TITLE
Fix bug with solving puzzles with length != 5

### DIFF
--- a/WordleSolver.py
+++ b/WordleSolver.py
@@ -274,7 +274,7 @@ class Solver:
             while (not topWord):
                 print('Please enter the word you used: ', end='')
                 topWord = input()
-                if len(topWord) != 5 or not topWord.isalpha():
+                if len(topWord) != self.puzzleSize or not topWord.isalpha():
                     topWord = ''
                 else:
                     topWord = topWord.lower()


### PR DESCRIPTION
Hello! This PR removes a small bug, appearing in solving puzzles with word length != 5 letters. You had a hardcodded "5" in asking user to write his own word (if he hadn't used suggested ones), so I cannot write my long word (program is asking for 5 letters while word has another length). Changed it to self.puzzleSize